### PR TITLE
Return type bool

### DIFF
--- a/include/ArduinoJson/JsonObjectSubscript.hpp
+++ b/include/ArduinoJson/JsonObjectSubscript.hpp
@@ -29,7 +29,7 @@ class JsonObjectSubscript
   }
 
   template <typename TValue>
-  FORCE_INLINE TValue is() const {
+  FORCE_INLINE bool is() const {
     return _object.is<TValue>(_key);
   }
 


### PR DESCRIPTION
Request[str].is<JsonObject&>() functionality failing because is() function returning TValue whereas it should return bool
